### PR TITLE
Fix flaky unit test

### DIFF
--- a/QROrganizer.Data/Services/Implementation/AsyncDelay.cs
+++ b/QROrganizer.Data/Services/Implementation/AsyncDelay.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Threading.Tasks;
+using QROrganizer.Data.Services.Interface;
+
+namespace QROrganizer.Data.Services.Implementation;
+
+public class AsyncDelay : IAsyncDelay
+{
+    public Task Delay(TimeSpan timeSpan)
+    {
+        return Task.Delay(timeSpan);
+    }
+}

--- a/QROrganizer.Data/Services/Interface/IAsyncDelay.cs
+++ b/QROrganizer.Data/Services/Interface/IAsyncDelay.cs
@@ -1,0 +1,9 @@
+using System;
+using System.Threading.Tasks;
+
+namespace QROrganizer.Data.Services.Interface;
+
+public interface IAsyncDelay
+{
+    Task Delay(TimeSpan timeSpan);
+}


### PR DESCRIPTION
- Use abstraction around Task.Delay to fix flaky unit tests requiring tests to run for a specific duration of time